### PR TITLE
Fix compilation errors with "-Werror"

### DIFF
--- a/src/Ambient.cpp
+++ b/src/Ambient.cpp
@@ -224,6 +224,8 @@ Ambient::send(uint32_t tmout) {
         inChar = this->client->read();
 #if AMBIENT_DEBUG
         Serial.write(inChar);
+#else
+        (void)inChar;
 #endif
     }
 
@@ -294,6 +296,8 @@ Ambient::bulk_send(char *buf, uint32_t tmout) {
         inChar = this->client->read();
 #if AMBIENT_DEBUG
         Serial.write(inChar);
+#else
+        (void)inChar;
 #endif
     }
 
@@ -389,6 +393,8 @@ Ambient::delete_data(const char * userKey, uint32_t tmout) {
         inChar = this->client->read();
 #if AMBIENT_DEBUG
         Serial.write(inChar);
+#else
+        (void)inChar;
 #endif
     }
 
@@ -424,7 +430,6 @@ Ambient::getchannel(const char * userKey, const char * devKey, unsigned int & ch
     }
 
     char str[1024];
-    char inChar;
 
     memset(str, 0, sizeof(str));
     sprintf(str, "GET /api/v2/channels/?userKey=%s&devKey=%s HTTP/1.1\r\n", userKey, devKey);


### PR DESCRIPTION
Fix the following errors:
```
error: variable 'inChar' set but not used [-Werror=unused-but-set-variable]
```

----

Arduino IDE 2.2.1 で ESP32-C3 用に本ライブラリを使おうとしたところ、`-Werror` オプションが有効になっていたため、コンパイルエラーが発生してしまいました。
`inChar` に値を設定したあと使用していないところが3箇所、`inChar` 自体を使用していないところが1箇所あったので修正しました。