### PR TITLE
Fixed an issue that json parsing was not performed correctly

### DIFF
--- a/src/Ambient.cpp
+++ b/src/Ambient.cpp
@@ -468,7 +468,7 @@ Ambient::getchannel(const char * userKey, const char * devKey, unsigned int & ch
     to = buf.indexOf("\",", from);
     channelId = buf.substring(from, to).toInt();
     from = buf.indexOf("\"writeKey\":\"") + strlen("\"writeKey\":\"");
-    to = buf.indexOf("\",", from);
+    to = buf.indexOf("\"}", from);
     buf.substring(from, to).toCharArray(writeKey, len);
 
     this->client->stop();


### PR DESCRIPTION
https://github.com/AmbientDataInc/Ambient_ESP8266_lib/issues/6 示した通り、version 1.0.5 において、getchannel関数内でのjsonパースが正常に機能しない問題を修正しました。
Arduino JSONなどを用いる手もありますが、修正が長大になるため、最小限の修正にとどめました。